### PR TITLE
Prevent unwanted changes in calendar link input

### DIFF
--- a/src/index/template.html
+++ b/src/index/template.html
@@ -50,7 +50,7 @@
     <dialog id="modal" class="modal">
       <div class="modal-box">
         </h3>
-        <input type="text" class="input input-bordered w-full text-sm" id="link"></input>
+        <input type="text" class="input input-bordered w-full text-sm" id="link" readonly="readonly"></input>
         <div class="modal-action">
           <form method="dialog">
             <button class="btn">Close</button>


### PR DESCRIPTION
I wanted to copy/paste the link but inadvertently typed a character.

Closing and opening the modal did not set the value for some reason, the easiest way to fix is to add readonly attribute.

Not tested on my side, so I hope this won't break something. But considering the change I would be surprised. :-)

PS : Thanks for the update with the Paralympics calendars!